### PR TITLE
Further work to modernize code and eliminate compiler warnings

### DIFF
--- a/src/0.alloc.c
+++ b/src/0.alloc.c
@@ -56,7 +56,7 @@ balloc(int n, struct coreblk **p, int size)
 	int i;
 	struct coreblk *q;
 
-	n = (n + sizeof(i) - 1) / sizeof(i);	/* convert bytes to wds to ensure ints always at wd boundaries */
+	n = (n + sizeof(intptr_t) - 1) / sizeof(intptr_t);	/* convert bytes to wds to ensure ints always at wd boundaries */
 	for (q = *p;; q = q->nxtblk) {
 		if (!q) {
 			q = morespace(n, p, size);

--- a/src/0.def.c
+++ b/src/0.def.c
@@ -5,7 +5,7 @@ int routnum;
 FILE *debfd;
 LOGICAL routerr;
 int nodenum, accessnum;
-int **graph;
+intptr_t **graph;
 int progtype;
 VERT stopvert, retvert;
 VERT START;

--- a/src/0.graph.c
+++ b/src/0.graph.c
@@ -14,9 +14,9 @@ prgraph(void)
 	if (progress)
 		fprintf(stderr, "prgraph():\n");
 	for (v = 0; v < nodenum; ++v) {
-		fprintf(stderr, "%d %s:", v, typename[NTYPE(v)]);
+		fprintf(stderr, "%" PRIdPTR " %s:", v, typename[NTYPE(v)]);
 		for (i = 0; i < ARCNUM(v); ++i) {
-			fprintf(stderr, "%d ", ARC(v, i));
+			fprintf(stderr, "%" PRIdPTR " ", ARC(v, i));
 			ASSERT(UNDEFINED <= ARC(v, i)
 			       && ARC(v, i) < nodenum, prgraph);
 		}
@@ -37,9 +37,9 @@ prtr(VERT v, int tab)
 	int i;
 
 	TABOVER(tab);
-	fprintf(stderr, "%d %s:", v, typename[NTYPE(v)]);
+	fprintf(stderr, "%" PRIdPTR " %s:", v, typename[NTYPE(v)]);
 	for (i = 0; i < ARCNUM(v); ++i)
-		fprintf(stderr, " %d", ARC(v, i));
+		fprintf(stderr, " %" PRIdPTR, ARC(v, i));
 	fprintf(stderr, "\n");
 	for (i = 0; i < CHILDNUM(v); ++i) {
 		TABOVER(tab + 1);

--- a/src/0.list.c
+++ b/src/0.list.c
@@ -68,6 +68,6 @@ prlst(struct list *ls)
 	struct list *lp;
 
 	for (lp = ls; lp; lp = lp->nxtlist)
-		fprintf(stderr, "%d,", lp->elt);
+		fprintf(stderr, "%" PRIdPTR ",", lp->elt);
 	fprintf(stderr, "\n");
 }

--- a/src/0.parts.c
+++ b/src/0.parts.c
@@ -35,7 +35,7 @@ int childper[TYPENUM] = {
 	2, 1
 };
 
-int arcsper[TYPENUM] = {
+intptr_t arcsper[TYPENUM] = {
 	1, 2, 2, 3, 0,
 	-(FIXED + 1), 1, -(FIXED + 1), 1, 1,
 	1, 1, 2, 0, 0,
@@ -59,7 +59,7 @@ lchild(VERT v, int i)
 	return (&graph[v][nonarcs[NTYPE(v)] - i - 1]);
 }
 
-int *
+intptr_t *
 vxpart(VERT v, int type, int j)
 {
 	ASSERT((NTYPE(v) == type) && (0 <= j)
@@ -67,7 +67,7 @@ vxpart(VERT v, int type, int j)
 	return (&graph[v][FIXED + j]);
 }
 
-int *
+intptr_t *
 expres(VERT v)
 {
 	int ty;
@@ -78,21 +78,21 @@ expres(VERT v)
 	return (&graph[v][FIXED]);
 }
 
-int *
+intptr_t *
 negpart(VERT v)
 {
 	ASSERT(NTYPE(v) == IFVX || NTYPE(v) == ACASVX, negpart);
 	return (&graph[v][FIXED + 1]);
 }
 
-int *
+intptr_t *
 predic(VERT v)
 {
 	ASSERT(NTYPE(v) == IFVX || NTYPE(v) == ACASVX, predic);
 	return (&graph[v][FIXED]);
 }
 
-int *
+intptr_t *
 level(VERT v)
 {
 	ASSERT(NTYPE(v) == GOVX || NTYPE(v) == BRKVX
@@ -100,7 +100,7 @@ level(VERT v)
 	return (&graph[v][FIXED]);
 }
 
-int *
+intptr_t *
 stlfmt(VERT v, int n)
 {
 	ASSERT(NTYPE(v) == STLNVX || NTYPE(v) == FMTVX, stlfmt);

--- a/src/1.hash.c
+++ b/src/1.hash.c
@@ -8,7 +8,8 @@
 extern int match[], symclass[], action[], newstate[];
 extern char symbol[];
 long *hashtab;
-int *value, *chain;
+int *value;
+intptr_t *chain;
 
 extern FILE *infd;
 
@@ -164,7 +165,7 @@ hash(long x)
 }
 
 void
-addref(long x, int *ptr)	/* put ptr in chain for x or assign value of x to *ptr */
+addref(long x, intptr_t *ptr)	/* put ptr in chain for x or assign value of x to *ptr */
 {
 	int index;
 
@@ -181,13 +182,14 @@ addref(long x, int *ptr)	/* put ptr in chain for x or assign value of x to *ptr 
 		*ptr = 0;
 	else
 		*ptr = chain[index];
-	chain[index] = ptr;
+	chain[index] = (intptr_t)ptr;
 }
 
 void
-fixvalue(long x, int ptr)
+fixvalue(long x, intptr_t ptr)
 {
-	int *temp1, *temp2, index, temp0;
+	intptr_t *temp1, temp2;
+	int index, temp0;
 
 	index = hash(x);
 
@@ -206,7 +208,7 @@ fixvalue(long x, int ptr)
 		while (temp1 != 0) {
 			temp2 = *temp1;
 			*temp1 = ptr;
-			temp1 = temp2;
+			temp1 = (intptr_t *)temp2;
 		}
 		temp0 = index;
 		index = value[index];
@@ -217,7 +219,8 @@ fixvalue(long x, int ptr)
 void
 connect(long x, long y)
 {
-	int *temp, index, temp2;
+	intptr_t *temp;
+	int index, temp2;
 
 	index = hash(x);
 
@@ -228,7 +231,7 @@ connect(long x, long y)
 			temp = &chain[index];
 
 			while (*temp != 0)
-				temp = *temp;
+				temp = (intptr_t *)*temp;
 
 			*temp = chain[hash(y)];
 		}

--- a/src/1.recog.c
+++ b/src/1.recog.c
@@ -44,7 +44,7 @@ recognize(int type, int ifflag)	/* if ifflag = 1, statement is if()type; otherwi
 		num1 =
 		    makenode(IFVX, TRUE, TRUE, label(0), 2, arctype,
 			     arclab);
-		PRED(num1) = pred;
+		PRED(num1) = (intptr_t)pred;
 	}
 
 	arctype[0] = (nest >= 0) ? nest : -2;
@@ -115,7 +115,7 @@ recognize(int type, int ifflag)	/* if ifflag = 1, statement is if()type; otherwi
 				ONDISK(num) = endline - endcom;
 				CODELINES(num) = 1;
 			} else {
-				BEGCODE(num) = stcode;
+				BEGCODE(num) = (intptr_t)stcode;
 				ONDISK(num) = FALSE;
 				CODELINES(num) = 1;
 			}
@@ -139,7 +139,7 @@ recognize(int type, int ifflag)	/* if ifflag = 1, statement is if()type; otherwi
 		}
 		dostack[doptr] = label(1);
 		doloc[doptr] = num1;	/* stack link to node after loop */
-		INC(num1) = inc;
+		INC(num1) = (intptr_t)inc;
 		num =
 		    makenode(ITERVX, TRUE, FALSE, implicit, 1, arctype,
 			     arclab);
@@ -178,8 +178,8 @@ recognize(int type, int ifflag)	/* if ifflag = 1, statement is if()type; otherwi
 		num =
 		    makenode(IOVX, !ifflag, !ifflag, label(0), 3, arctype,
 			     arclab);
-		PRERW(num) = prerw;
-		POSTRW(num) = postrw;
+		PRERW(num) = (intptr_t)prerw;
+		POSTRW(num) = (intptr_t)postrw;
 		if (reflab)
 			addref(reflab->labelt, &FMTREF(num));
 		else
@@ -199,13 +199,13 @@ recognize(int type, int ifflag)	/* if ifflag = 1, statement is if()type; otherwi
 		num =
 		    makenode(type, !ifflag, !ifflag, label(0), nlabs - 1,
 			     arctype, arclab);
-		EXP(num) = expr;
+		EXP(num) = (intptr_t)expr;
 		break;
 	case ASVX:
 		num =
 		    makenode(ASVX, !ifflag, !ifflag, label(0), 1, arctype,
 			     arclab);
-		EXP(num) = expr;
+		EXP(num) = (intptr_t)expr;
 		addref(label(1), &LABREF(num));
 		break;
 	case entry:
@@ -292,7 +292,7 @@ makeif(int first, long labe, char *test, long arc1, long arc2)	/* construct IFVX
 	arclab[0] = arc1;
 	arclab[1] = arc2;
 	num = makenode(IFVX, first, first, labe, 2, arctype, arclab);
-	PRED(num) = test;
+	PRED(num) = (intptr_t)test;
 	return (num);
 }
 
@@ -364,12 +364,12 @@ compcase(LOGICAL ifflag)		/* turn computed goto into case statement */
 	num =
 	    makenode(SWCHVX, !ifflag, !ifflag, label(0), d, arctype,
 		     arclab);
-	EXP(num) = expr;
+	EXP(num) = (intptr_t)expr;
 
 	str = challoc(6 * nlabs);	/* 5 digits + , or \0 per label */
 	for (i = 0; i < d; ++i)	/* construct list of values for each label */
 		EXP(arctype[i]) =
-		    stralloc(str, accum(str, linelabs->nxtlab, arclab[i]));
+		    (intptr_t)stralloc(str, accum(str, linelabs->nxtlab, arclab[i]));
 	chfree(str, 6 * nlabs);
 	chfree(arctype, sizeof(*arctype) * nlabs);
 	chfree(arclab, sizeof(*arclab) * nlabs);

--- a/src/2.dfs.c
+++ b/src/2.dfs.c
@@ -100,7 +100,7 @@ chreach(void)
 		    && NTYPE(v) != STOPVX && NTYPE(v) != RETVX) {
 			unreach = TRUE;
 			if (debug)
-				fprintf(stderr, "node %d unreachable\n", v);
+				fprintf(stderr, "node %" PRIdPTR " unreachable\n", v);
 		}
 	if (unreach)
 		error(": unreachable statements - ", "will be ignored", "");
@@ -152,9 +152,9 @@ insloop(VERT v)			/* insert LOOPVX, ITERVX at node number v */
 }
 
 void
-exchange(int **p1, int **p2)		/* exchange values of p1, p2 */
+exchange(intptr_t **p1, intptr_t **p2)		/* exchange values of p1, p2 */
 {
-	int *temp;
+	intptr_t *temp;
 
 	temp = *p1;
 	*p1 = *p2;
@@ -162,9 +162,9 @@ exchange(int **p1, int **p2)		/* exchange values of p1, p2 */
 }
 
 void
-exchange2(int *p1, int *p2)		/* exchange values of p1, p2 */
+exchange2(intptr_t *p1, intptr_t *p2)		/* exchange values of p1, p2 */
 {
-	int temp;
+	intptr_t temp;
 
 	temp = *p1;
 	*p1 = *p2;

--- a/src/4.def.h
+++ b/src/4.def.h
@@ -2,7 +2,7 @@
 #define NOTAB	FALSE
 #define TABOVER(n)	tabover(n, outfd)
 #define OUTSTR(x)	fprintf(outfd, "%s", x)
-#define OUTNUM(x)	fprintf(outfd, "%d", x)
+#define OUTNUM(x)	fprintf(outfd, "%" PRIdPTR, x)
 
 
 extern LOGICAL *brace;

--- a/src/4.out.c
+++ b/src/4.out.c
@@ -69,7 +69,7 @@ LOGICAL tabfirst)		/* FALSE if doing IF of ELSE IF */
 	case COMPVX:
 		OUTSTR("goto ");
 		if (type == ASGOVX) {
-			OUTSTR(EXP(v));
+			OUTSTR((char *)EXP(v));
 			OUTSTR(",");
 		}
 		OUTSTR("(");
@@ -81,7 +81,7 @@ LOGICAL tabfirst)		/* FALSE if doing IF of ELSE IF */
 		OUTSTR(")");
 		if (type == COMPVX) {
 			OUTSTR(",");
-			OUTSTR(EXP(v));
+			OUTSTR((char *)EXP(v));
 		}
 		OUTSTR("\n");
 		break;
@@ -89,7 +89,7 @@ LOGICAL tabfirst)		/* FALSE if doing IF of ELSE IF */
 		OUTSTR("assign ");
 		OUTNUM(LABEL(LABREF(v)));
 		OUTSTR(" to ");
-		OUTSTR(EXP(v));
+		OUTSTR((char *)EXP(v));
 		OUTSTR("\n");
 		break;
 	case IFVX:
@@ -120,7 +120,7 @@ LOGICAL tabfirst)		/* FALSE if doing IF of ELSE IF */
 		break;
 	case DOVX:
 		OUTSTR("DO ");
-		OUTSTR(INC(v));
+		OUTSTR((char *)INC(v));
 		newlevel(v, 0, tab + 1, YESTAB);
 		break;
 	case LOOPVX:
@@ -150,7 +150,7 @@ LOGICAL tabfirst)		/* FALSE if doing IF of ELSE IF */
 		OUTSTR("SWITCH");
 		if (DEFINED(EXP(v))) {
 			OUTSTR("(");
-			OUTSTR(EXP(v));
+			OUTSTR((char *)EXP(v));
 			OUTSTR(")");
 		}
 		newlevel(v, 0, tab + 1, YESTAB);
@@ -161,7 +161,7 @@ LOGICAL tabfirst)		/* FALSE if doing IF of ELSE IF */
 		if (type == ACASVX)
 			prpred(v, FALSE);
 		else
-			OUTSTR(EXP(v));
+			OUTSTR((char *)EXP(v));
 		OUTSTR(":\n");
 		newlevel(v, 0, tab + 1, YESTAB);
 		if (type == ACASVX && DEFINED(LCHILD(v, ELSE))) {
@@ -171,7 +171,7 @@ LOGICAL tabfirst)		/* FALSE if doing IF of ELSE IF */
 		}
 		break;
 	case IOVX:
-		OUTSTR(PRERW(v));
+		OUTSTR((char *)PRERW(v));
 		ndcomma = FALSE;
 		if (DEFINED(FMTREF(v))) {
 			OUTNUM(LABEL(FMTREF(v)));
@@ -191,7 +191,7 @@ LOGICAL tabfirst)		/* FALSE if doing IF of ELSE IF */
 			OUTNUM(LABEL(ARC(v, ERREQ)));
 			ndcomma = TRUE;
 		}
-		OUTSTR(POSTRW(v));
+		OUTSTR((char *)POSTRW(v));
 		OUTSTR("\n");
 		break;
 	}
@@ -237,7 +237,7 @@ prpred(VERT v, LOGICAL addpar)
 		OUTSTR("(");
 	if (NEG(v))
 		OUTSTR("!(");
-	OUTSTR(PRED(v));
+	OUTSTR((char *)PRED(v));
 	if (NEG(v))
 		OUTSTR(")");
 	if (addpar)
@@ -249,7 +249,7 @@ prlab(int n, int tab)
 {
 	TABOVER(tab);
 	OUTSTR("~");
-	OUTNUM(n);
+	OUTNUM((intptr_t)n);
 	OUTSTR(" ");
 }
 
@@ -258,7 +258,7 @@ prstln(VERT v, int tab)
 {
 	ASSERT(NTYPE(v) == STLNVX || NTYPE(v) == FMTVX, prstln);
 	if (!ONDISK(v)) {
-		OUTSTR(BEGCODE(v));
+		OUTSTR((char *)BEGCODE(v));
 		OUTSTR("\n");
 	} else {
 		empseek(BEGCODE(v));

--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -1,3 +1,12 @@
+2022-01-20         Jay Logue             <jay.logue@gmail.com>
+
+	* 0.alloc.c, 0.def.c, 0.graph.c, 0.list.c, 0.parts.c,
+	1.hash.c, 1.recog.c, 2.dfs.c, 4.def.h, 4.out.c,
+	allfuncs.h, def.h: Use intptr_t for any integers that
+	may be used to hold pointers. Use PRIdPTR when printing
+	any such integers.
+	* makefile: Removed -m32 compiler option
+
 2022-01-19         Arnold D. Robbins     <arnold@skeeve.com>
 
 	* tree.c (str_copy): Removed. Replaced all uses with strcpy.
@@ -31,7 +40,7 @@
 	(uptolow): Use tolower, isupper.
 	* allfuncs.h (str_copy): Removed.
 
-2022-01-18         Jay Logue             <jay@stoaster.com>
+2022-01-18         Jay Logue             <jay.logue@gmail.com>
 
 	* 0.parts.c (create): Fix use of realloc.
 	* 1.recog.c (recognize): Init num and num1.

--- a/src/allfuncs.h
+++ b/src/allfuncs.h
@@ -34,12 +34,12 @@ extern void prlst(struct list *ls);
 /* 0.parts.c: */
 extern VERT *arc(VERT v, int i);
 extern VERT *lchild(VERT v, int i);
-extern int *vxpart(VERT v, int type, int j);
-extern int *expres(VERT v);
-extern int *negpart(VERT v);
-extern int *predic(VERT v);
-extern int *level(VERT v);
-extern int *stlfmt(VERT v, int n);
+extern intptr_t *vxpart(VERT v, int type, int j);
+extern intptr_t *expres(VERT v);
+extern intptr_t *negpart(VERT v);
+extern intptr_t *predic(VERT v);
+extern intptr_t *level(VERT v);
+extern intptr_t *stlfmt(VERT v, int n);
 extern int create(int type, int arcnum);
 
 /* 0.string.c: */
@@ -88,8 +88,8 @@ extern void hash_init(void);
 extern void hash_check(void);
 extern void hash_free(void);
 extern int hash(long x);
-extern void addref(long x, int *ptr);
-extern void fixvalue(long x, int ptr);
+extern void addref(long x, intptr_t *ptr);
+extern void fixvalue(long x, intptr_t ptr);
 extern void connect(long x, long y);
 extern void clear(long x);
 
@@ -123,8 +123,8 @@ extern void search(VERT v);
 extern void chreach(void);
 extern void addloop(void);
 extern void insloop(VERT v);
-extern void exchange(int **p1, int **p2);
-extern void exchange2(int *p1, int *p2);
+extern void exchange(intptr_t **p1, intptr_t **p2);
+extern void exchange2(intptr_t *p1, intptr_t *p2);
 extern void repsearch(VERT v);
 
 /* 2.dom.c: */

--- a/src/def.h
+++ b/src/def.h
@@ -1,15 +1,19 @@
+#include <stdint.h>
+#include <inttypes.h>
+
 #define ASSERT(P, R)	{if (!(P)) {fprintf(stderr, "failed assertion in routine " #R ": " #P "\n"); abort();}}
 
 extern int routnum, routerr;
 extern long rtnbeg;		/* number of chars up to beginnine of curernt routing */
-extern int **graph, nodenum;
+extern intptr_t **graph;
+extern int nodenum;
 extern int stopflg;		/* turns off generation of stop statements */
 
 #define TRUE 1
 #define FALSE 0
 #define LOGICAL int
-#define VERT int
-#define DEFINED(v)	(v >= 0)
+#define VERT intptr_t
+#define DEFINED(v)	(v != -1)
 #define UNDEFINED	-1
 
 /* node types */
@@ -42,7 +46,7 @@ extern int stopflg;		/* turns off generation of stop statements */
 extern int hascom[TYPENUM];		/* FALSE for types with no comments, 2 otherwise */
 extern int nonarcs[TYPENUM];		/* number of wds per node other than arcs */
 extern VERT *arc(), *lchild();
-extern int *vxpart(), *negpart(), *predic(), *expres(), *level(), *stlfmt();
+extern intptr_t *vxpart(), *negpart(), *predic(), *expres(), *level(), *stlfmt();
 /* node parts */
 #define FIXED 4		/* number of wds needed in every node */
 #define NTYPE(v)	graph[v][0]
@@ -90,7 +94,7 @@ extern int *vxpart(), *negpart(), *predic(), *expres(), *level(), *stlfmt();
 
 /* also COMPVX, ASGOVX, SWCHVX, and DUMVX contain wd for number of arcs */
 /* location of this wd specified by negative entry in arcsper */
-extern int arcsper[TYPENUM];
+extern intptr_t arcsper[TYPENUM];
 
 /* also nodes contain wds for children as specified by childper */
 extern int childper[TYPENUM];

--- a/src/makefile
+++ b/src/makefile
@@ -1,4 +1,4 @@
-CFLAGS=-g -g3 -m32 -Wall
+CFLAGS=-g -g3 -Wall
 YFLAGS=-d
 
 0FILES.c = 0.alloc.c 0.args.c 0.def.c 0.extr.c 0.graph.c 0.list.c 0.parts.c 0.string.c


### PR DESCRIPTION
@arnoldrobbins : Here's my take on the changes needed to get structure to build in a modern C environment.

The main thrust of the change is to use the intptr_t type anywhere the code uses an integer that may contain a pointer.  This change, coupled with some casting to the appropriate pointer types, should allow the code to run on systems where `sizeof(int)` < `sizeof(void *)`.

Beyond this, I fixed some minor bugs and massaged the code to cope with modern gcc's pedantries (see the commit comment for a more detailed description of the changes).  With all this done, the code now compiles without warning using -Wall -O3 (and without -m32).

I should note that the resultant code is almost completely untested, as I lack a good test case with which to validate its behavior.  But I presume you have plenty of these to try.

Hopefully you find this helpful.
